### PR TITLE
Social media

### DIFF
--- a/dwebsummit/dwebsummit_frontend/templates/dwebsummit/_matrix_join.html
+++ b/dwebsummit/dwebsummit_frontend/templates/dwebsummit/_matrix_join.html
@@ -1,6 +1,3 @@
 <div class="matrix-join">
-  <span class="matrix-text">
-    #decentralizedweb-general:matrix.org
-  </span>
-  <span class="matrix-text">(<a href="https://matrix.org">More info</a>)</span>
+  <a href="https://riot.im/app/#/room/#decentralizedweb-general:matrix.org">#decentralizedweb-general:matrix.org</a> (<a href="https://matrix.org">More info</a>)
 </div>

--- a/dwebsummit/dwebsummit_frontend/templates/dwebsummit/_matrix_join.html
+++ b/dwebsummit/dwebsummit_frontend/templates/dwebsummit/_matrix_join.html
@@ -1,3 +1,1 @@
-<div class="matrix-join">
-  <a href="https://riot.im/app/#/room/#decentralizedweb-general:matrix.org">#decentralizedweb-general:matrix.org</a> (<a href="https://matrix.org">More info</a>)
-</div>
+<a href="https://riot.im/app/#/room/#decentralizedweb-general:matrix.org">#decentralizedweb-general:matrix.org</a> (<a href="https://matrix.org">More info</a>)

--- a/dwebsummit/dwebsummit_frontend/templates/dwebsummit/_slackin.html
+++ b/dwebsummit/dwebsummit_frontend/templates/dwebsummit/_slackin.html
@@ -1,1 +1,1 @@
-<script async defer src="https://decentralizedweb-slack-join.herokuapp.com/slackin.js?large"></script>
+<a href="https://decentralizedweb-slack-join.herokuapp.com">Decentralized Web on Slack</a>

--- a/dwebsummit/dwebsummit_frontend/templates/dwebsummit/page-templates/home.html
+++ b/dwebsummit/dwebsummit_frontend/templates/dwebsummit/page-templates/home.html
@@ -57,7 +57,7 @@
           <i class="fas fa-envelope-open-text"></i>
         </td>
         <td>
-          <a href="https://mailchi.mp/55b3dd624527/dwebcamp">Sign up</a> to receive updates by email.
+          <a href="https://mailchi.mp/55b3dd624527/dwebcamp">Sign up</a> to receive updates by email
         </td>
       </tr>
       <tr>
@@ -89,7 +89,7 @@
           <i class="fab fa-twitter"></i>
         </td>
         <td>
-          <a href="https://twitter.com/search?q=%23DWebSummit">#DWebCamp</a>
+          <a href="https://twitter.com/search?q=%23DWebCamp">#DWebCamp</a>
         </td>
       </tr>
       <tr>
@@ -97,7 +97,7 @@
           <i class="fas fa-envelope"></i>
         </td>
         <td>
-          <a class="email" href="mailto:dwebcamp@archive.org">dwebcamp@archive.org</a>
+          <a href="mailto:dwebcamp@archive.org">dwebcamp@archive.org</a>
         </td>
       </tr>
     </table>


### PR DESCRIPTION
- Remove Slack bubble because script error causes it to fail on Firefox and Chrome, replaced by text link to https://decentralizedweb-slack-join.herokuapp.com
- Link Matrix text to https://riot.im/app/#/room/#decentralizedweb-general:matrix.org
- Fix Twitter link to correct hashtag
- Fix font style of email