### PR TITLE
WEBDEV-2282: Add In Kind Sponsors Section

### DIFF
--- a/dwebsummit/dwebsummit_admin/models.py
+++ b/dwebsummit/dwebsummit_admin/models.py
@@ -63,10 +63,12 @@ class Sponsor(models.Model):
 
     REGULAR_SPONSOR = '0'
     LEAD_SPONSOR = '1'
+    INKIND_SPONSOR = '2'
 
     SPONSOR_TYPES = (
         (REGULAR_SPONSOR, 'Regular Sponsor'),
         (LEAD_SPONSOR, 'Lead Sponsor'),
+        (INKIND_SPONSOR, 'In-Kind Sponsor')
     )
 
     type = models.CharField(

--- a/dwebsummit/dwebsummit_admin/models.py
+++ b/dwebsummit/dwebsummit_admin/models.py
@@ -68,7 +68,7 @@ class Sponsor(models.Model):
     SPONSOR_TYPES = (
         (REGULAR_SPONSOR, 'Regular Sponsor'),
         (LEAD_SPONSOR, 'Lead Sponsor'),
-        (INKIND_SPONSOR, 'In-Kind Sponsor')
+        (INKIND_SPONSOR, 'In Kind Sponsor')
     )
 
     type = models.CharField(

--- a/dwebsummit/dwebsummit_frontend/static/css/_desktop.scss
+++ b/dwebsummit/dwebsummit_frontend/static/css/_desktop.scss
@@ -81,7 +81,7 @@
     margin-top: 0rem;
     margin-bottom: 2rem;
   }
-  #sponsors {
+  .sponsors {
     .grid { padding-left:5px; }
     section {
       .sponsors-grid {

--- a/dwebsummit/dwebsummit_frontend/static/css/_desktop.scss
+++ b/dwebsummit/dwebsummit_frontend/static/css/_desktop.scss
@@ -82,10 +82,14 @@
     margin-bottom: 2rem;
   }
   .sponsors {
-    .grid { padding-left:5px; }
+    .grid {
+      padding-left: 5px;
+    }
     section {
       .sponsors-grid {
-        .box { padding: 0 1rem; display: inline-block;}
+        .box {
+          padding: 0 1rem;
+          display: inline-block;}
         .sponsor-img {
           height: 10rem;
         }

--- a/dwebsummit/dwebsummit_frontend/static/css/_desktop.scss
+++ b/dwebsummit/dwebsummit_frontend/static/css/_desktop.scss
@@ -89,7 +89,8 @@
       .sponsors-grid {
         .box {
           padding: 0 1rem;
-          display: inline-block;}
+          display: inline-block;
+        }
         .sponsor-img {
           height: 10rem;
         }

--- a/dwebsummit/dwebsummit_frontend/static/css/_desktop.scss
+++ b/dwebsummit/dwebsummit_frontend/static/css/_desktop.scss
@@ -81,21 +81,21 @@
     margin-top: 0rem;
     margin-bottom: 2rem;
   }
-  section.sponsors {
+  #sponsors {
     .grid { padding-left:5px; }
-    .lead-sponsors-grid, .sponsors-grid {
-      .box { padding: 0 1rem; display: inline-block;}
-    }
-    .lead-sponsors-grid {
-      .sponsor-img {
-        height: 25rem;
-        width: auto;
+    section {
+      .sponsors-grid {
+        .box { padding: 0 1rem; display: inline-block;}
+        .sponsor-img {
+          height: 10rem;
+          width: auto;
+        }
       }
-    }
-    .sponsors-grid {
-      .sponsor-img {
-        height: 10rem;
-        width: auto;
+      &.lead {
+        .sponsor-img {
+          height: 25rem;
+          width: auto;
+        }
       }
     }
   }

--- a/dwebsummit/dwebsummit_frontend/static/css/_desktop.scss
+++ b/dwebsummit/dwebsummit_frontend/static/css/_desktop.scss
@@ -88,13 +88,11 @@
         .box { padding: 0 1rem; display: inline-block;}
         .sponsor-img {
           height: 10rem;
-          width: auto;
         }
       }
       &.lead {
         .sponsor-img {
           height: 25rem;
-          width: auto;
         }
       }
     }

--- a/dwebsummit/dwebsummit_frontend/static/css/main.scss
+++ b/dwebsummit/dwebsummit_frontend/static/css/main.scss
@@ -578,7 +578,7 @@ i.info-icon {
   }
 }
 
-#sponsors {
+.sponsors {
   padding-left: 2rem;
   padding-right: 2rem;
 

--- a/dwebsummit/dwebsummit_frontend/static/css/main.scss
+++ b/dwebsummit/dwebsummit_frontend/static/css/main.scss
@@ -578,28 +578,38 @@ i.info-icon {
   }
 }
 
-section.sponsors {
-  .lead-sponsors-grid, .sponsors-grid {
-    .box {
-      margin-bottom: 1rem;
-      display: block;
-      text-align: center;
+#sponsors {
+  padding-left: 2rem;
+  padding-right: 2rem;
+
+  section {
+    padding-left: 0;
+
+    .sponsors-grid {
+      .box {
+        margin-bottom: 1rem;
+        display: block;
+        text-align: center;
+      }
+      .sponsor-img {
+        width: auto;
+        max-width: 100%;
+      }
     }
-    .sponsor-img {
-      width: auto;
-      max-width: 100%;
+
+    &.lead {
+      .sponsor-img {
+        height: 13rem;
+      }
+    }
+
+    &.regular, &.in-kind {
+      .sponsor-img {
+        height: 7rem;
+      }
     }
   }
-  .lead-sponsors-grid {
-    .sponsor-img {
-      height: 13rem;
-    }
-  }
-  .sponsors-grid {
-    .sponsor-img {
-      height: 7rem;
-    }
-  }
+
   .sp-footer {
     margin-top: 5rem;
     color: black;

--- a/dwebsummit/dwebsummit_frontend/templates/dwebsummit/_sponsorship_section.html
+++ b/dwebsummit/dwebsummit_frontend/templates/dwebsummit/_sponsorship_section.html
@@ -2,7 +2,7 @@
   <h1>{{section_title}}</h1>
   <div class="sponsors-grid">
     {% for sponsor in sponsors %}
-      <div id="sponsor_{{sponsor.slug}}" class="box">
+      <div class="box">
         <a href="{{sponsor.url}}" target="_blank">
           <img class="sponsor-img" src="{{sponsor.image.url}}" alt="{{sponsor.title}}" />
         </a>

--- a/dwebsummit/dwebsummit_frontend/templates/dwebsummit/_sponsorship_section.html
+++ b/dwebsummit/dwebsummit_frontend/templates/dwebsummit/_sponsorship_section.html
@@ -1,0 +1,12 @@
+<section class="{{section_class}}">
+  <h1>{{section_title}}</h1>
+  <div class="sponsors-grid">
+    {% for sponsor in sponsors %}
+      <div id="sponsor_{{sponsor.slug}}" class="box">
+        <a href="{{sponsor.url}}" target="_blank">
+          <img class="sponsor-img" src="{{sponsor.image.url}}" alt="{{sponsor.title}}" />
+        </a>
+      </div>
+    {% endfor %}
+  </div>
+</section>

--- a/dwebsummit/dwebsummit_frontend/templates/dwebsummit/page-templates/home.html
+++ b/dwebsummit/dwebsummit_frontend/templates/dwebsummit/page-templates/home.html
@@ -118,47 +118,23 @@
 <!-- Section I: Sponsors -->
 <div class="row" id="sponsors">
   {% if lead_sponsors|length > 0  %}
-  <section class="lead">
-    <h1>Lead Sponsors</h1>
-    <div class="sponsors-grid">
-      {% for sponsor in lead_sponsors %}
-        <div id="sponsor_{{sponsor.slug}}" class="box">
-          <a href="{{sponsor.url}}" target="_blank">
-            <img class="sponsor-img" src="{{sponsor.image.url}}" alt="{{sponsor.title}}" />
-          </a>
-        </div>
-      {% endfor %}
-    </div>
-  </section>
+    {% with section_title="Lead Sponsors", section_class="lead", sponsors=lead_sponsors %}
+      {% include "dwebsummit/_sponsorship_section.html" %}
+    {% endwith %}
   {% endif %}
+
   {% if sponsors|length > 0  %}
-  <section class="regular">
-    <h1>Sponsors</h1>
-    <div class="sponsors-grid">
-      {% for sponsor in sponsors %}
-        <div id="sponsor_{{sponsor.slug}}" class="box">
-          <a href="{{sponsor.url}}" target="_blank">
-            <img class="sponsor-img" src="{{sponsor.image.url}}" alt="{{sponsor.title}}" />
-          </a>
-        </div>
-      {% endfor %}
-    </div>
-  </section>
+    {% with section_title="Sponsors", section_class="regular", sponsors=sponsors %}
+      {% include "dwebsummit/_sponsorship_section.html" %}
+    {% endwith %}
   {% endif %}
+
   {% if inkind_sponsors|length > 0  %}
-  <section class="in-kind">
-    <h1>In Kind Sponsors</h1>
-    <div class="sponsors-grid">
-      {% for sponsor in inkind_sponsors %}
-        <div id="sponsor_{{sponsor.slug}}" class="box">
-          <a href="{{sponsor.url}}" target="_blank">
-            <img class="sponsor-img" src="{{sponsor.image.url}}" alt="{{sponsor.title}}" />
-          </a>
-        </div>
-      {% endfor %}
-    </div>
-  </section>
+    {% with section_title="In Kind Sponsors", section_class="in-kind", sponsors=inkind_sponsors %}
+      {% include "dwebsummit/_sponsorship_section.html" %}
+    {% endwith %}
   {% endif %}
+
   <div class="sp-footer">
     <p>
     Want to become a DWeb Summit Sponsor?  Contact <a href="mailto:dwebcamp@archive.org">dwebcamp@archive.org</a>

--- a/dwebsummit/dwebsummit_frontend/templates/dwebsummit/page-templates/home.html
+++ b/dwebsummit/dwebsummit_frontend/templates/dwebsummit/page-templates/home.html
@@ -116,12 +116,13 @@
 <!-- End Section H -->
 
 <!-- Section I: Sponsors -->
-<div class="row">
-  <section id="sponsors" class="sponsors">
+<div class="row" id="sponsors">
+  {% if lead_sponsors|length > 0  %}
+  <section class="lead">
     <h1>Lead Sponsors</h1>
-    <div class="lead-sponsors-grid">
+    <div class="sponsors-grid">
       {% for sponsor in lead_sponsors %}
-        <div id="sponsor_{{sponsor.slug}}" class="sponsor lead box">
+        <div id="sponsor_{{sponsor.slug}}" class="box">
           <a href="{{sponsor.url}}" target="_blank">
             <img class="sponsor-img" src="{{sponsor.image.url}}" alt="{{sponsor.title}}" />
           </a>
@@ -129,23 +130,40 @@
       {% endfor %}
     </div>
   </section>
-  <section class="sponsors">
+  {% endif %}
+  {% if sponsors|length > 0  %}
+  <section class="regular">
     <h1>Sponsors</h1>
     <div class="sponsors-grid">
       {% for sponsor in sponsors %}
-        <div id="sponsor_{{sponsor.slug}}" class="sponsor box">
+        <div id="sponsor_{{sponsor.slug}}" class="box">
           <a href="{{sponsor.url}}" target="_blank">
             <img class="sponsor-img" src="{{sponsor.image.url}}" alt="{{sponsor.title}}" />
           </a>
         </div>
       {% endfor %}
     </div>
-    <div class="sp-footer">
-      <p>
-      Want to become a DWeb Summit Sponsor?  Contact <a href="mailto:dwebcamp@archive.org">dwebcamp@archive.org</a>
-      </p>
+  </section>
+  {% endif %}
+  {% if inkind_sponsors|length > 0  %}
+  <section class="in-kind">
+    <h1>In-Kind Sponsors</h1>
+    <div class="sponsors-grid">
+      {% for sponsor in inkind_sponsors %}
+        <div id="sponsor_{{sponsor.slug}}" class="box">
+          <a href="{{sponsor.url}}" target="_blank">
+            <img class="sponsor-img" src="{{sponsor.image.url}}" alt="{{sponsor.title}}" />
+          </a>
+        </div>
+      {% endfor %}
     </div>
   </section>
+  {% endif %}
+  <div class="sp-footer">
+    <p>
+    Want to become a DWeb Summit Sponsor?  Contact <a href="mailto:dwebcamp@archive.org">dwebcamp@archive.org</a>
+    </p>
+  </div>
 </div>
 <!-- End Section I -->
 

--- a/dwebsummit/dwebsummit_frontend/templates/dwebsummit/page-templates/home.html
+++ b/dwebsummit/dwebsummit_frontend/templates/dwebsummit/page-templates/home.html
@@ -116,7 +116,7 @@
 <!-- End Section H -->
 
 <!-- Section I: Sponsors -->
-<div class="row" id="sponsors">
+<div class="row sponsors">
   {% if lead_sponsors|length > 0  %}
     {% with section_title="Lead Sponsors", section_class="lead", sponsors=lead_sponsors %}
       {% include "dwebsummit/_sponsorship_section.html" %}

--- a/dwebsummit/dwebsummit_frontend/templates/dwebsummit/page-templates/home.html
+++ b/dwebsummit/dwebsummit_frontend/templates/dwebsummit/page-templates/home.html
@@ -147,7 +147,7 @@
   {% endif %}
   {% if inkind_sponsors|length > 0  %}
   <section class="in-kind">
-    <h1>In-Kind Sponsors</h1>
+    <h1>In Kind Sponsors</h1>
     <div class="sponsors-grid">
       {% for sponsor in inkind_sponsors %}
         <div id="sponsor_{{sponsor.slug}}" class="box">

--- a/dwebsummit/dwebsummit_frontend/views.py
+++ b/dwebsummit/dwebsummit_frontend/views.py
@@ -27,6 +27,7 @@ def build_context_data(context):
     context['people'] = Person.objects.all().order_by('first_name').prefetch_related('video_set')
     context['lead_sponsors'] = Sponsor.objects.filter(type=Sponsor.LEAD_SPONSOR)
     context['sponsors'] = Sponsor.objects.filter(type=Sponsor.REGULAR_SPONSOR)
+    context['inkind_sponsors'] = Sponsor.objects.filter(type=Sponsor.INKIND_SPONSOR)
     context['text_fields'] = TextField.objects.all()
     context['projects'] = Project.objects.filter(is_published=True).order_by('title')
     context['builders_day_projects'] = Project.objects.filter(is_published=True,


### PR DESCRIPTION
This adds a third sponsorship category: In Kind Sponsors

We have an enum of sponsorship types and this adds one more option to it and exposes it to the templates.

This also DRYs up the sponsorship markup and styling and hides a sponsorship section if we don't have any sponsors of that type.

![Screen Shot 2019-05-21 at 10 02 07 AM](https://user-images.githubusercontent.com/51138/58115965-0cc1d180-7bb0-11e9-8b83-95672ccf459e.png)
