### PR TITLE
WEBDEV-2299: Add DWebCamp Banner

### DIFF
--- a/dwebsummit/dwebsummit_frontend/static/css/_top_banner.scss
+++ b/dwebsummit/dwebsummit_frontend/static/css/_top_banner.scss
@@ -1,0 +1,21 @@
+.top-banner {
+  background-color: yellow;
+  text-align: center;
+
+  .cta {
+    font-weight: bold;
+  }
+
+  a {
+    color: black;
+    display: block;
+    padding: 10px;
+  }
+
+  button {
+    border-color: white;
+    background-color: black;
+    color: yellow;
+    margin-left: 1rem;
+  }
+}

--- a/dwebsummit/dwebsummit_frontend/static/css/main.scss
+++ b/dwebsummit/dwebsummit_frontend/static/css/main.scss
@@ -12,6 +12,7 @@ $medium_container_width: 110rem;
 @import "slider";
 @import "wallop";
 @import "modal";
+@import "top_banner";
 
 $green: #3fc380;
 $blue: #4a90e2;

--- a/dwebsummit/dwebsummit_frontend/templates/dwebsummit/_top_banner.html
+++ b/dwebsummit/dwebsummit_frontend/templates/dwebsummit/_top_banner.html
@@ -1,0 +1,5 @@
+<div class="top-banner">
+  <a href="https://dwebcamp.org">
+    <span class="">Join us</span> for the <span class="cta">2019 DWeb Camp</span> -- July 18-21 near SF <button>Learn More</button>
+  </a>
+</div>

--- a/dwebsummit/dwebsummit_frontend/templates/dwebsummit/layout.html
+++ b/dwebsummit/dwebsummit_frontend/templates/dwebsummit/layout.html
@@ -19,6 +19,9 @@
         <script src="/static/js/vendor/cash.min.js" type="text/javascript"></script>
     </head>
     <body class="page-{{title|replace(" ", "-")}}">
+        <div id="banner-wrapper">
+          {% include "dwebsummit/_top_banner.html" %}
+        </div>
 
         <div id="header-wrapper">
           {% include "dwebsummit/_header.html" %}


### PR DESCRIPTION
Add a banner to the top of the site for the 2019 DWebCamp

**Note** This is a MR into the 2018 "master" branch since the 2018 and 2019 sites use the same base repo.

![Screen Shot 2019-05-21 at 1 33 22 PM](https://user-images.githubusercontent.com/51138/58128716-21609280-7bcd-11e9-82ce-74f47661611c.png)
